### PR TITLE
Fixes an issue where timeout/depth could only be single-digit numbers

### DIFF
--- a/lib/App/PrereqGrapher.pm
+++ b/lib/App/PrereqGrapher.pm
@@ -46,12 +46,12 @@ has verbose => (
 
 has depth => (
     is => 'ro',
-    isa => sub { croak "depth must be an integer\n" unless $_[0] =~ /^\d$/; },
+    isa => sub { croak "depth must be an integer\n" unless $_[0] =~ /^\d+$/; },
 );
 
 has timeout => (
     is => 'ro',
-    isa => sub { croak "timeout must be an integer\n" unless $_[0] =~ /^\d$/; },
+    isa => sub { croak "timeout must be an integer\n" unless $_[0] =~ /^\d+$/; },
 );
 
 sub new_with_options


### PR DESCRIPTION
```
zoffix@ZofMain:/tmp/g$ prereq-grapher -t 30
isa check for "timeout" failed: timeout must be an integer
 at (eval 196) line 88.
```

The regex that checks the arguments in the old version of the code, only allowed a single digit for `timeout`/`depth` arguments. This pull fixes the issue.
